### PR TITLE
add layout for content, select all list tag

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -6,7 +6,7 @@ import CssBaseline from "@mui/material/CssBaseline";
 import { CacheProvider } from "@emotion/react";
 import ThemeProvider from "../src/theme";
 import createEmotionCache from "../src/createEmotionCache";
-import { styled } from "@mui/material";
+import ContentLayout from "../src/layouts/ContentLayout";
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();
@@ -22,7 +22,9 @@ export default function MyApp(props) {
       <ThemeProvider>
         {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
         <CssBaseline />
-        <Component {...pageProps} />
+        <ContentLayout>
+          <Component {...pageProps} />
+        </ContentLayout>
       </ThemeProvider>
     </CacheProvider>
   );

--- a/src/layouts/ContentLayout.js
+++ b/src/layouts/ContentLayout.js
@@ -1,0 +1,9 @@
+import { Container } from "@mui/material";
+
+const ContentLayout = ({ children }) => (
+  <Container>
+    <main>{children}</main>
+  </Container>
+);
+
+export default ContentLayout;

--- a/src/layouts/ContentLayout.js
+++ b/src/layouts/ContentLayout.js
@@ -1,9 +1,22 @@
 import { Container } from "@mui/material";
+import { useRouter } from "next/router";
+import { useRef } from "react";
 
-const ContentLayout = ({ children }) => (
-  <Container>
-    <main>{children}</main>
-  </Container>
-);
+const ContentLayout = ({ children }) => {
+  const router = useRouter();
+  const isWV = useRef(router.pathname.startsWith("/wv"));
+
+  return (
+    <>
+      {isWV.current ? (
+        <Container className="wv-content__container">
+          <main>{children}</main>
+        </Container>
+      ) : (
+        <main>{children}</main>
+      )}
+    </>
+  );
+};
 
 export default ContentLayout;

--- a/styles/global.css
+++ b/styles/global.css
@@ -40,6 +40,6 @@ code {
 }
 
 /* Must select all to apply for markdown list-items rendered by MDX  */
-li {
+.wv-content__container li {
   margin-left: 1em;
 }

--- a/styles/global.css
+++ b/styles/global.css
@@ -30,23 +30,16 @@ code {
   background-color: rgba(135, 131, 120, 0.15);
   color: #eb5757;
   padding: 0.2em 0.4em;
-  border-radius: 3px;
+  border-radius: 4px;
 }
-p {
-  margin: 10px 0;
-}
-li {
-  margin: 20px 0 20px 35px;
-}
-blockquote {
-  margin-left: 35px;
-}
-a {
-  color: rgb(79, 129, 189);
-  text-decoration: underline;
-}
+
 .ch-section-link {
   background-color: rgba(191, 191, 191, 0.2);
   background-color: rgba(255, 0, 0, 0.2);
   padding: 0 5px;
+}
+
+/* Must select all to apply for markdown list-items rendered by MDX  */
+li {
+  margin-left: 1em;
 }


### PR DESCRIPTION
- Add layout for content readability
- Remove most of style rules in global.css but list tags selector

Reason: 
- List rendered by MDX from markdown syntax list have the bullets overflow left align border
- To maintain the ability to write markdown syntax, we must style all lists after all .mdx rendered.


