### PR TITLE
Fixed: ContentLayout never re-render

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -7,6 +7,7 @@ import { CacheProvider } from "@emotion/react";
 import ThemeProvider from "../src/theme";
 import createEmotionCache from "../src/createEmotionCache";
 import ContentLayout from "../src/layouts/ContentLayout";
+import { useRouter } from "next/router";
 
 // Client-side cache, shared for the whole session of the user in the browser.
 const clientSideEmotionCache = createEmotionCache();

--- a/src/layouts/ContentLayout.js
+++ b/src/layouts/ContentLayout.js
@@ -1,13 +1,9 @@
 import { Container } from "@mui/material";
 import { useRouter } from "next/router";
-import { useMemo, useRef } from "react";
 
 const ContentLayout = ({ children }) => {
   const router = useRouter();
-  const isWV = useMemo(
-    () => router.pathname.startsWith("/wv"),
-    [router.pathname]
-  );
+  const isWV = router.pathname.startsWith("/wv");
 
   return (
     <>

--- a/src/layouts/ContentLayout.js
+++ b/src/layouts/ContentLayout.js
@@ -1,14 +1,17 @@
 import { Container } from "@mui/material";
 import { useRouter } from "next/router";
-import { useRef } from "react";
+import { useMemo, useRef } from "react";
 
 const ContentLayout = ({ children }) => {
   const router = useRouter();
-  const isWV = useRef(router.pathname.startsWith("/wv"));
+  const isWV = useMemo(
+    () => router.pathname.startsWith("/wv"),
+    [router.pathname]
+  );
 
   return (
     <>
-      {isWV.current ? (
+      {isWV ? (
         <Container className="wv-content__container">
           <main>{children}</main>
         </Container>


### PR DESCRIPTION
- ContentLayout not re-render, so the logic will never re-run to check router
- Made isWV depends on router.pathname update. 